### PR TITLE
docs(nx): specify return values for stateful operations

### DIFF
--- a/nx/lib/nx.ex
+++ b/nx/lib/nx.ex
@@ -3411,6 +3411,8 @@ defmodule Nx do
   Or use `Nx.global_default_backend/1` as it changes the
   default backend on all processes.
 
+  The function returns the value that was previously set as backend.
+
   ## Examples
 
       iex> Nx.default_backend({EXLA.Backend, device: :cuda})
@@ -3446,6 +3448,7 @@ defmodule Nx do
         config: [nx: [default_backend: {EXLA.Backend, device: :cuda}]]
       )
 
+  The function returns the value that was previously set as global backend.
   """
   @doc type: :backend
   def global_default_backend(backend) do

--- a/nx/lib/nx/defn.ex
+++ b/nx/lib/nx/defn.ex
@@ -253,6 +253,15 @@ defmodule Nx.Defn do
 
         config :nx, :#{@app_key}, [compiler: EXLA, client: :cuda]
 
+  The function returns the values that were previously set as default
+  options.
+
+  ## Examples
+
+      iex> Nx.Defn.default_options(compiler: EXLA, client: :cuda)
+      []
+      iex> Nx.Defn.default_options()
+      [compiler: EXLA, client: :cuda]
   """
   def default_options(options) when is_list(options) do
     Process.put(@compiler_key, options) || Application.fetch_env!(:nx, @app_key)
@@ -272,6 +281,8 @@ defmodule Nx.Defn do
 
       config :nx, :#{@app_key}, [compiler: EXLA, client: :cuda]
 
+  The function returns the values that were previously set as global
+  default options.
   """
   def global_default_options(options) when is_list(options) do
     current = Application.fetch_env!(:nx, @app_key)


### PR DESCRIPTION
Update the docs for `Nx.default_backend/1`,
`Nx.Defn.default_options/1` and their corresponding "global" version to highlight that they return the value that was previouslu set.